### PR TITLE
Implement visitor pattern for AST nodes and add AstPrinterVisitor

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,14 @@
-use  parser::grammar::ProgramParser;
+use parser::grammar::ProgramParser;
+use parser::visitor::AstPrinterVisitor::AstPrinterVisitor;
+use parser::visitor::Visitable;
 
 fn main() {
     let expr = ProgramParser::new()
-        .parse("let x = let y=4 in (y+4) in (x + 3)")
+        .parse("let x = let z=4 in (z*4),y=6 in let j=20 in (j+x+y)")
         .unwrap();
-    println!("{:?}", expr);
+    let mut printer = AstPrinterVisitor::new();
+    expr.accept(&mut printer);
 }
-
-
-
-
-
 
 
 // mod ast;

--- a/src/parser/src/ast/atoms/atom.rs
+++ b/src/parser/src/ast/atoms/atom.rs
@@ -64,3 +64,18 @@ impl Atom {
     }
 
 }
+
+
+impl Visitable for Atom {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        match self {
+            Atom::LetIn(letin) => visitor.visit_letin(letin),
+            Atom::Block(block) => visitor.visit_block(block),
+            Atom::Group(expr) => visitor.visit_expression(expr),
+            Atom::NumberLiteral(literal) => visitor.visit_literal(literal),
+            Atom::BooleanLiteral(literal) => visitor.visit_literal(literal),
+            Atom::StringLiteral(literal) => visitor.visit_literal(literal),
+            Atom::Variable(identifier) => visitor.visit_identifier(identifier),
+        }
+    }
+}

--- a/src/parser/src/ast/atoms/block.rs
+++ b/src/parser/src/ast/atoms/block.rs
@@ -1,5 +1,7 @@
 use super::super::Expression;
 use crate::tokens::GroupingOperator;
+use super::super::Visitable;
+use super::super::Visitor;
 
 #[derive(Debug)]
 pub struct ExpressionList {
@@ -12,6 +14,13 @@ impl ExpressionList {
             expressions,
         }
     }
+}
+
+impl Visitable for ExpressionList {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_expression_list(self);
+    }
+    
 }
 #[derive(Debug)]
 pub struct Block {
@@ -32,4 +41,11 @@ impl Block {
             expression_list,
         }
     }
+}
+
+impl Visitable for Block {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_block(self);
+    }
+    
 }

--- a/src/parser/src/ast/atoms/letin.rs
+++ b/src/parser/src/ast/atoms/letin.rs
@@ -2,6 +2,8 @@ use crate::tokens::*;
 use crate::BinOp;
 use crate::Expression;
 use crate::Atom;
+use super::super::Visitable;
+use super::super::Visitor;
 
 #[derive(Debug)]
 pub struct Assignment {
@@ -18,6 +20,13 @@ impl Assignment {
             body: Box::new(body),
         }
     }
+}
+
+impl Visitable for Assignment {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_assignment(self);
+    }
+    
 }
 #[derive(Debug)]
 pub struct LetIn {
@@ -37,4 +46,11 @@ impl LetIn {
             body: Box::new(body),
         }
     }
+}
+
+impl Visitable for LetIn {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_letin(self);
+    }
+    
 }

--- a/src/parser/src/ast/expressions/binoperation.rs
+++ b/src/parser/src/ast/expressions/binoperation.rs
@@ -1,11 +1,12 @@
 use super::Expression;
 use crate::tokens::BinOp;
-
+use super::super::Visitor;
+use super::super::Visitable;
 #[derive(Debug)]
 pub struct BinaryOp{
-    left: Box<Expression>,
-    right: Box<Expression>,
-    operator: BinOp,
+   pub left: Box<Expression>,
+   pub right: Box<Expression>,
+   pub operator: BinOp,
 }
 
 impl BinaryOp {
@@ -16,4 +17,11 @@ impl BinaryOp {
             operator,
         }
     }
+}
+
+impl Visitable for BinaryOp {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_binary_op(self);
+    }
+    
 }

--- a/src/parser/src/ast/expressions/expressions.rs
+++ b/src/parser/src/ast/expressions/expressions.rs
@@ -1,6 +1,8 @@
 use super::*;
 use crate::Atom;
 use crate::BinOp;
+use super::super::Visitor;
+use super::super::Visitable;
 
 #[derive(Debug)]
 pub enum Expression{
@@ -16,5 +18,11 @@ impl Expression {
 
     pub fn new_atom(atom: Atom) -> Self {
         Expression::Atom(Box::new(atom))
+    }
+}
+
+impl Visitable for Expression {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_expression(&self);
     }
 }

--- a/src/parser/src/ast/mod.rs
+++ b/src/parser/src/ast/mod.rs
@@ -4,6 +4,10 @@ pub use atoms::*;
 pub mod expressions;
 pub use expressions::*;
 
+pub mod visitor;
+pub use visitor::Visitor;
+pub use visitor::Visitable;
+
 pub mod program;
 pub use program::Program;
 

--- a/src/parser/src/ast/program.rs
+++ b/src/parser/src/ast/program.rs
@@ -1,4 +1,6 @@
 use super::ExpressionList;
+use super::Visitable;
+use super::Visitor;
 
 #[derive(Debug)]
 pub struct Program {
@@ -11,4 +13,11 @@ impl Program {
             expression_list
         }
     }
+}
+
+impl Visitable for Program {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_program(self);
+    }
+    
 }

--- a/src/parser/src/ast/visitor/AstPrinterVisitor.rs
+++ b/src/parser/src/ast/visitor/AstPrinterVisitor.rs
@@ -1,0 +1,89 @@
+use crate::visitor::Visitor;
+use crate::visitor::Visitable;
+use crate::ast;
+use crate::tokens;
+
+pub struct AstPrinterVisitor {
+    pub indent: usize,
+}
+
+impl AstPrinterVisitor {
+    pub fn new() -> Self {
+        AstPrinterVisitor { indent: 0 }
+    }
+    fn pad(&self) -> String {
+        "  ".repeat(self.indent)
+    }
+}
+
+impl Visitor for AstPrinterVisitor {
+    fn visit_program(&mut self, program: &ast::Program) {
+        println!("{}Program", self.pad());
+        self.indent += 1;
+        program.expression_list.accept(self);
+        self.indent -= 1;
+    }
+    fn visit_expression_list(&mut self, expr_list: &ast::ExpressionList) {
+        println!("{}ExpressionList", self.pad());
+        self.indent += 1;
+        for expr in &expr_list.expressions {
+            expr.accept(self);
+        }
+        self.indent -= 1;
+    }
+    fn visit_expression(&mut self, expr: &ast::Expression) {
+        match expr {
+            ast::Expression::BinaryOp(binop) => binop.accept(self),
+            ast::Expression::Atom(atom) => atom.accept(self),
+        }
+    }
+    fn visit_atom(&mut self, atom: &ast::atoms::atom::Atom) {
+        use crate::ast::atoms::atom::Atom::*;
+        match atom {
+            LetIn(letin) => letin.accept(self),
+            Block(block) => block.accept(self),
+            Group(expr) => {
+                println!("{}Group", self.pad());
+                expr.accept(self);
+            }
+            NumberLiteral(lit) => lit.accept(self),
+            BooleanLiteral(lit) => lit.accept(self),
+            StringLiteral(lit) => lit.accept(self),
+            Variable(id) => id.accept(self),
+        }
+    }
+    fn visit_binary_op(&mut self, binop: &ast::expressions::binoperation::BinaryOp) {
+        println!("{}BinaryOp: {}", self.pad(), binop.operator);
+        self.indent += 1;
+        binop.left.accept(self);
+        binop.right.accept(self);
+        self.indent -= 1;
+    }
+    fn visit_letin(&mut self, letin: &ast::atoms::letin::LetIn) {
+        println!("{}LetIn", self.pad());
+        self.indent += 1;
+        for assign in &letin.bindings {
+            assign.accept(self);
+        }
+        letin.body.accept(self);
+        self.indent -= 1;
+    }
+    fn visit_assignment(&mut self, assign: &ast::atoms::letin::Assignment) {
+        println!("{}Assignment: {} {}", self.pad(), assign.identifier, assign.op);
+        self.indent += 1;
+        assign.body.accept(self);
+        self.indent -= 1;
+    }
+    fn visit_block(&mut self, block: &ast::atoms::block::Block) {
+        println!("{}Block", self.pad());
+        self.indent += 1;
+        block.expression_list.accept(self);
+        self.indent -= 1;
+    }
+    fn visit_literal(&mut self, literal: &tokens::Literal) {
+        println!("{}Literal: {}", self.pad(), literal);
+    }
+    fn visit_identifier(&mut self, identifier: &tokens::Identifier) {
+        println!("{}Identifier: {}", self.pad(), identifier);
+    }
+}

--- a/src/parser/src/ast/visitor/mod.rs
+++ b/src/parser/src/ast/visitor/mod.rs
@@ -1,0 +1,6 @@
+pub mod visitor;
+pub mod AstPrinterVisitor;
+
+pub use visitor::Visitor;
+pub use visitor::Visitable;
+

--- a/src/parser/src/ast/visitor/visitor.rs
+++ b/src/parser/src/ast/visitor/visitor.rs
@@ -1,0 +1,19 @@
+use crate::ast;
+use crate::tokens;
+pub trait Visitor {
+    fn visit_program(&mut self, program: &ast::Program);
+    fn visit_expression_list(&mut self, expr_list: &ast::ExpressionList);
+    fn visit_expression(&mut self, expr: &ast::Expression);
+    fn visit_atom(&mut self, atom: &ast::atoms::atom::Atom);
+    fn visit_binary_op(&mut self, binop: &ast::expressions::binoperation::BinaryOp);
+    fn visit_letin(&mut self, letin: &ast::atoms::letin::LetIn);
+    fn visit_assignment(&mut self, assign: &ast::atoms::letin::Assignment);
+    fn visit_block(&mut self, block: &ast::atoms::block::Block);
+    fn visit_literal(&mut self, literal: &tokens::Literal);
+    fn visit_identifier(&mut self, identifier: &tokens::Identifier);
+    // Agrega más métodos según tus nodos
+}
+
+pub trait Visitable {
+    fn accept<V: Visitor>(&self, visitor: &mut V);
+}

--- a/src/parser/src/tokens/identifier.rs
+++ b/src/parser/src/tokens/identifier.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 use super::position::Position;
+use super::super::Visitable;
+use super::super::Visitor;
 #[derive(Debug)]
 pub struct Identifier {
     pub name: String,
@@ -19,4 +21,11 @@ impl fmt::Display for Identifier {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self.name)
     }
+}
+
+impl Visitable for Identifier {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_identifier(&self);
+    }
+    
 }

--- a/src/parser/src/tokens/literal.rs
+++ b/src/parser/src/tokens/literal.rs
@@ -1,5 +1,7 @@
 use std::fmt;
 use super::position::Position;
+use super::super::Visitable;
+use super::super::Visitor;
 
 #[derive(Debug)]
 pub enum Literal {
@@ -16,4 +18,11 @@ impl fmt::Display for Literal {
             Literal::Bool(b, _) => write!(f, "{}", b),
         }
     }
+}
+
+impl Visitable for Literal {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_literal(&self);
+    }
+    
 }


### PR DESCRIPTION
This pull request introduces a visitor pattern implementation to the AST (Abstract Syntax Tree) of the parser, enabling traversal and operations on AST nodes without modifying their structure. The most significant changes include the addition of `Visitor` and `Visitable` traits, the implementation of these traits for various AST components, and the creation of an `AstPrinterVisitor` for debugging purposes.

### Visitor Pattern Implementation:

* Added `Visitor` and `Visitable` traits in `src/parser/src/ast/visitor/visitor.rs` to define a consistent interface for traversing and interacting with AST nodes. (`[src/parser/src/ast/visitor/visitor.rsR1-R19](diffhunk://#diff-acc6084241a92ab7a9dd63471c5c80ce4f492e6bdb2f81ee11b057bdc55af63aR1-R19)`)
* Implemented the `Visitable` trait for key AST components such as `Atom`, `ExpressionList`, `Block`, `LetIn`, `Assignment`, `BinaryOp`, `Expression`, `Identifier`, and `Literal`, enabling them to accept visitors. (`[[1]](diffhunk://#diff-ea4d7a2a0fbccc9cb7a26cdf8bb43dcc0a1375afbf6879b8d0893b7b184ecaebR67-R81)`, `[[2]](diffhunk://#diff-98c457017eeda0bb6c572be353b09f8a566bec732def9705f0a5d0ebc1ca2e12R18-R24)`, `[[3]](diffhunk://#diff-98c457017eeda0bb6c572be353b09f8a566bec732def9705f0a5d0ebc1ca2e12R45-R51)`, `[[4]](diffhunk://#diff-ce2a88a76bf5df87b7fc2d524860572b75304786f69b87ce76e26946e7b357a9R24-R30)`, `[[5]](diffhunk://#diff-ce2a88a76bf5df87b7fc2d524860572b75304786f69b87ce76e26946e7b357a9R50-R56)`, `[[6]](diffhunk://#diff-af594d31319b6cac817e5a7a481c689e9ce12a4bad449d1c19922c0a85ce080cR21-R27)`, `[[7]](diffhunk://#diff-0337ae89f0ee1a1d456eec741b2c6aae3da94ff2547d4a6d5aa289f7e9f57d95R23-R28)`, `[[8]](diffhunk://#diff-d33cfe3e088291d43fa305f6f6e1ffbe496922e2353b1966ef77a60e6bae1e16R25-R31)`, `[[9]](diffhunk://#diff-8775e667d6f69077a4648a290bd2cd523150981e4bd8c43f871081105764c087R22-R28)`)

### Debugging and AST Traversal:

* Introduced `AstPrinterVisitor` in `src/parser/src/ast/visitor/AstPrinterVisitor.rs` to traverse the AST and print its structure for debugging. This visitor implements the `Visitor` trait and supports all major AST node types. (`[src/parser/src/ast/visitor/AstPrinterVisitor.rsR1-R89](diffhunk://#diff-2cb151794218b1527a44a955d17e514803d509efa2cd5cb4fea514ad8f1abde4R1-R89)`)
* Updated the `main` function in `src/main.rs` to use the `AstPrinterVisitor` for visualizing the AST of parsed input. (`[src/main.rsR2-L15](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcR2-L15)`)

### Codebase Organization:

* Added a new `visitor` module under `src/parser/src/ast/visitor/` to encapsulate the visitor-related logic. (`[src/parser/src/ast/visitor/mod.rsR1-R6](diffhunk://#diff-dd969073c460dacf17a8415fa48dbab9b9630278907152c9f3d66dafeb3e9689R1-R6)`)
* Updated imports in various files to include the `Visitor` and `Visitable` traits where needed. (`[[1]](diffhunk://#diff-98c457017eeda0bb6c572be353b09f8a566bec732def9705f0a5d0ebc1ca2e12R3-R4)`, `[[2]](diffhunk://#diff-ce2a88a76bf5df87b7fc2d524860572b75304786f69b87ce76e26946e7b357a9R5-R6)`, `[[3]](diffhunk://#diff-af594d31319b6cac817e5a7a481c689e9ce12a4bad449d1c19922c0a85ce080cL3-R9)`, `[[4]](diffhunk://#diff-0337ae89f0ee1a1d456eec741b2c6aae3da94ff2547d4a6d5aa289f7e9f57d95R4-R5)`, `[[5]](diffhunk://#diff-38c1e022a30ffd20e911c43ca52ae0c3573362c3c86b89eb98c0708eb631f3bbR2-R3)`, `[[6]](diffhunk://#diff-d33cfe3e088291d43fa305f6f6e1ffbe496922e2353b1966ef77a60e6bae1e16R3-R4)`, `[[7]](diffhunk://#diff-8775e667d6f69077a4648a290bd2cd523150981e4bd8c43f871081105764c087R3-R4)`)

These changes collectively enhance the parser's flexibility by decoupling operations from the AST structure, allowing for reusable and extensible visitor implementations.