### PR TITLE
Dev michell

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use parser::grammar::ProgramParser;
-use parser::visitor::AstPrinterVisitor::AstPrinterVisitor;
+use parser::visitor::ast_printer_visitor::AstPrinterVisitor;
 use parser::visitor::Visitable;
 
 fn strip_comments(source: &str) -> Result<String, String> {
@@ -81,7 +81,7 @@ fn strip_comments(source: &str) -> Result<String, String> {
 }
 
 fn main() {
-    let source = "let x=\"hola\" in x;
+    let source = "let x=\"hola\" in print(x);
     // This is a single-line comment
     print(x);
     /*

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,16 +81,24 @@ fn strip_comments(source: &str) -> Result<String, String> {
 }
 
 fn main() {
-    let source = "let x=\"hola\" in print(x);
-    // This is a single-line comment
-    print(x);
-    /*
-    This is a multi-line comment
-    */
+    let source = "
+    if (true)
     {
+     print(x);
+     print(let y=5 in y;);
+    }
+    elif (false)
+    {
+        print(x);
+        if (true)
+            print(y);
+        else
+            print(0);
+    }
+    else 
         print(y);
-        let z= 5 in z;
-    };";
+    
+   ";
 
     let cleaned_source = match strip_comments(source) {
         Ok(s) => s,

--- a/src/parser/src/ast/atoms/atom.rs
+++ b/src/parser/src/ast/atoms/atom.rs
@@ -2,6 +2,7 @@ use super::super::*;
 use super::letin::Assignment;
 use super::*;
 use crate::tokens::*;
+
 #[derive(Debug)]
 pub enum Atom{
 
@@ -12,8 +13,8 @@ pub enum Atom{
     BooleanLiteral(Literal),
     StringLiteral(Literal),
     Variable(Identifier),
+    Print(Print),
 }
-
 
 impl Atom {
 
@@ -63,6 +64,10 @@ impl Atom {
         Atom::Group(Box::new(expression))
     }
 
+    pub fn new_print(print_token: Keyword, expression: Expression) -> Self {
+        Atom::Print(Print::new(print_token, expression))
+    }
+
 }
 
 
@@ -76,6 +81,7 @@ impl Visitable for Atom {
             Atom::BooleanLiteral(literal) => visitor.visit_literal(literal),
             Atom::StringLiteral(literal) => visitor.visit_literal(literal),
             Atom::Variable(identifier) => visitor.visit_identifier(identifier),
+            Atom::Print(print) => visitor.visit_print(print),
         }
     }
 }

--- a/src/parser/src/ast/atoms/atom.rs
+++ b/src/parser/src/ast/atoms/atom.rs
@@ -7,6 +7,7 @@ use crate::tokens::*;
 pub enum Atom{
 
     LetIn(LetIn),
+    IfElse(IfElse),
     Block(Box<Block>),
     Group(Box<Expression>),
     NumberLiteral(Literal),
@@ -68,6 +69,24 @@ impl Atom {
         Atom::Print(Print::new(print_token, expression))
     }
 
+    pub fn new_ifelse(
+        if_token: Keyword,
+        condition: Box<Expression>,
+        then_branch: Box<Atom>,
+        elif_branches: Vec<(Keyword, Expression, Atom)>,
+        else_token: Keyword,
+        else_branch: Box<Atom>,
+    ) -> Self {
+        Atom::IfElse(IfElse::new(
+            if_token,
+            condition,
+            then_branch,
+            elif_branches,
+            else_token,
+            else_branch,
+        ))
+    }
+
 }
 
 
@@ -82,6 +101,7 @@ impl Visitable for Atom {
             Atom::StringLiteral(literal) => visitor.visit_literal(literal),
             Atom::Variable(identifier) => visitor.visit_identifier(identifier),
             Atom::Print(print) => visitor.visit_print(print),
+            Atom::IfElse(ifelse) => visitor.visit_ifelse(ifelse),
         }
     }
 }

--- a/src/parser/src/ast/atoms/ifelse.rs
+++ b/src/parser/src/ast/atoms/ifelse.rs
@@ -1,0 +1,42 @@
+use crate::ast::Atom;
+use crate::ast::Expression;
+use crate::tokens::Keyword;
+use super::super::Visitor;
+use super::super::Visitable;
+
+#[derive(Debug)]
+pub struct IfElse {
+    pub if_token: Keyword,
+    pub condition: Box<Expression>,
+    pub then_branch: Box<Atom>,
+    pub elif_branches: Vec<(Keyword, Expression, Atom)>, // (elif token, cond, branch)
+    pub else_token: Keyword,
+    pub else_branch: Box<Atom>,
+}
+
+impl IfElse {
+    pub fn new(
+        if_token: Keyword,
+        condition: Box<Expression>,
+        then_branch: Box<Atom>,
+        elif_branches: Vec<(Keyword, Expression, Atom)>,
+        else_token: Keyword,
+        else_branch: Box<Atom>,
+    ) -> Self {
+        Self {
+            if_token,
+            condition: condition,
+            then_branch: then_branch,
+            elif_branches,
+            else_token,
+            else_branch: else_branch,
+        }
+    }
+}
+
+impl Visitable for IfElse {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_ifelse(self);
+    }
+}
+

--- a/src/parser/src/ast/atoms/mod.rs
+++ b/src/parser/src/ast/atoms/mod.rs
@@ -8,3 +8,6 @@ pub use letin::LetIn;
 pub mod block;
 pub use block::Block;
 pub use block::ExpressionList;
+
+pub mod print;
+pub use print::Print;

--- a/src/parser/src/ast/atoms/mod.rs
+++ b/src/parser/src/ast/atoms/mod.rs
@@ -11,3 +11,6 @@ pub use block::ExpressionList;
 
 pub mod print;
 pub use print::Print;
+
+pub mod ifelse;
+pub use ifelse::IfElse;

--- a/src/parser/src/ast/atoms/print.rs
+++ b/src/parser/src/ast/atoms/print.rs
@@ -1,0 +1,25 @@
+use crate ::tokens::*;
+use super::super::Expression;
+use super::super::Visitor;
+use super::super::Visitable;
+
+#[derive(Debug)]
+pub struct Print {
+    pub print_token: Keyword,
+    pub expression: Box<Expression>,
+}
+
+impl Print {
+    pub fn new(print_token: Keyword, expression: Expression) -> Self {
+        Print {
+            print_token,
+            expression: Box::new(expression),
+        }
+    }
+}
+
+impl Visitable for Print {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_print(self);
+    }
+}

--- a/src/parser/src/ast/expressions/expressions.rs
+++ b/src/parser/src/ast/expressions/expressions.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::Atom;
 use crate::BinOp;
-use crate::tokens;
 use super::super::Visitor;
 use super::super::Visitable;
 

--- a/src/parser/src/ast/expressions/expressions.rs
+++ b/src/parser/src/ast/expressions/expressions.rs
@@ -9,7 +9,6 @@ use super::super::Visitable;
 pub enum Expression {
     BinaryOp(BinaryOp),
     Atom(Box<Atom>),
-    Print(Box<Expression>, tokens::Position), // Nueva variante
 }
 
 impl Expression {
@@ -20,10 +19,7 @@ impl Expression {
     pub fn new_atom(atom: Atom) -> Self {
         Expression::Atom(Box::new(atom))
     }
-
-    pub fn new_print(expr: Expression, pos: tokens::Position) -> Self {
-        Expression::Print(Box::new(expr), pos)
-    }
+   
 }
 
 impl Visitable for Expression {

--- a/src/parser/src/ast/expressions/mod.rs
+++ b/src/parser/src/ast/expressions/mod.rs
@@ -4,5 +4,3 @@ pub use expressions::Expression;
 pub mod binoperation;
 pub use binoperation::BinaryOp;
 
-pub mod ifelse;
-//pub use ifelse::IfElse;

--- a/src/parser/src/ast/visitor/ast_optimizer.rs
+++ b/src/parser/src/ast/visitor/ast_optimizer.rs
@@ -91,7 +91,7 @@ impl Visitor for AstOptimizer {
 
     fn visit_identifier(&mut self, _identifier: &crate::tokens::Identifier) {}
 
-    fn visit_print(&mut self, expr: &ast::Expression, _pos: &crate::tokens::Position) {
+    fn visit_print(&mut self, expr: &ast::atoms::print::Print) {
         expr.accept(self);
     }
 }

--- a/src/parser/src/ast/visitor/ast_printer_visitor.rs
+++ b/src/parser/src/ast/visitor/ast_printer_visitor.rs
@@ -52,6 +52,7 @@ impl Visitor for AstPrinterVisitor {
             StringLiteral(lit) => lit.accept(self),
             Variable(id) => id.accept(self),
             Print(print) => print.accept(self),
+            IfElse(ifelse) => ifelse.accept(self),
         }
     }
     fn visit_binary_op(&mut self, binop: &ast::expressions::binoperation::BinaryOp) {
@@ -94,4 +95,40 @@ impl Visitor for AstPrinterVisitor {
         expr.expression.accept(self);
         self.indent -= 1;
     }
+
+    fn visit_ifelse(&mut self, ifelse: &ast::atoms::ifelse::IfElse) {
+        println!("{}IfElse", self.pad());
+        self.indent += 1;
+        println!("{}If:", self.pad());
+        self.indent += 1;
+        println!("{}Condition:", self.pad());
+        self.indent += 1;
+        ifelse.condition.accept(self);
+        self.indent -= 1;
+        println!("{}Then:", self.pad());
+        self.indent += 1;
+        ifelse.then_branch.accept(self);
+        self.indent -= 1;
+        for (elif_token, elif_condition, elif_branch) in &ifelse.elif_branches {
+            
+            self.indent -=1 ;
+            println!("{}Elif:", self.pad());
+            self.indent += 1;
+            println!("{}Condition:", self.pad());
+            self.indent += 1;
+            elif_condition.accept(self);
+            self.indent -= 1;
+            println!("{}Branch:", self.pad());
+            self.indent += 1;
+            elif_branch.accept(self);
+            self.indent -= 1;
+        }
+        self.indent -= 1;
+        println!("{}Else:", self.pad());
+        self.indent += 1;
+        ifelse.else_branch.accept(self);
+        self.indent -= 1;
+    }
+
+
 }

--- a/src/parser/src/ast/visitor/ast_printer_visitor.rs
+++ b/src/parser/src/ast/visitor/ast_printer_visitor.rs
@@ -35,7 +35,7 @@ impl Visitor for AstPrinterVisitor {
         match expr {
             ast::Expression::BinaryOp(binop) => binop.accept(self),
             ast::Expression::Atom(atom) => atom.accept(self),
-            ast::Expression::Print(expr, pos) => self.visit_print(expr, pos),
+           
         }
     }
     fn visit_atom(&mut self, atom: &ast::atoms::atom::Atom) {
@@ -51,6 +51,7 @@ impl Visitor for AstPrinterVisitor {
             BooleanLiteral(lit) => lit.accept(self),
             StringLiteral(lit) => lit.accept(self),
             Variable(id) => id.accept(self),
+            Print(print) => print.accept(self),
         }
     }
     fn visit_binary_op(&mut self, binop: &ast::expressions::binoperation::BinaryOp) {
@@ -87,10 +88,10 @@ impl Visitor for AstPrinterVisitor {
     fn visit_identifier(&mut self, identifier: &tokens::Identifier) {
         println!("{}Identifier: {}", self.pad(), identifier);
     }
-    fn visit_print(&mut self, expr: &ast::Expression, pos: &tokens::Position) {
-        println!("{}Print (pos: {}-{})", self.pad(), pos.start, pos.end);
+    fn visit_print(&mut self, expr: &ast::atoms::print::Print) {
+        println!("{}Print", self.pad());
         self.indent += 1;
-        expr.accept(self);
+        expr.expression.accept(self);
         self.indent -= 1;
     }
 }

--- a/src/parser/src/ast/visitor/mod.rs
+++ b/src/parser/src/ast/visitor/mod.rs
@@ -1,5 +1,5 @@
 pub mod visitor;
-pub mod AstPrinterVisitor;
+pub mod ast_printer_visitor;
 
 pub use visitor::Visitor;
 pub use visitor::Visitable;

--- a/src/parser/src/ast/visitor/visitor.rs
+++ b/src/parser/src/ast/visitor/visitor.rs
@@ -12,7 +12,10 @@ pub trait Visitor {
     fn visit_literal(&mut self, literal: &tokens::Literal);
     fn visit_identifier(&mut self, identifier: &tokens::Identifier);
     fn visit_print(&mut self, expr: &ast::atoms::print::Print);
-}
+    fn visit_ifelse(&mut self, ifelse: &ast::atoms::ifelse::IfElse);
+        
+    }
+
 
 pub trait Visitable {
     fn accept<V: Visitor>(&self, visitor: &mut V);

--- a/src/parser/src/ast/visitor/visitor.rs
+++ b/src/parser/src/ast/visitor/visitor.rs
@@ -11,7 +11,7 @@ pub trait Visitor {
     fn visit_block(&mut self, block: &ast::atoms::block::Block);
     fn visit_literal(&mut self, literal: &tokens::Literal);
     fn visit_identifier(&mut self, identifier: &tokens::Identifier);
-    fn visit_print(&mut self, expr: &ast::Expression, pos: &tokens::Position);
+    fn visit_print(&mut self, expr: &ast::atoms::print::Print);
 }
 
 pub trait Visitable {

--- a/src/parser/src/grammar.lalrpop
+++ b/src/parser/src/grammar.lalrpop
@@ -9,20 +9,16 @@ pub Program: ast::Program = {
     <list:ExpressionList> => ast::Program::new(list),
 };
 
-pub Block: ast::Atom = {
-    <o:OpenBrace> <e:ExpressionList> <c:CloseBrace> => {
-        ast::Atom::new_block(o, e, c)
-    },
-};
 
 pub ExpressionList: ast::ExpressionList = {
-    <e:Expression> ";" <rest:ExpressionList> => {
+    <e:Expression> <rest:ExpressionList> => {
         let mut exprs = vec![e];
         exprs.extend(rest.expressions);
         ast::ExpressionList::new(exprs)
     },
-    <e:Expression> ";" => ast::ExpressionList::new(vec![e]),
+    <e:Expression> =>  ast::ExpressionList::new(vec![e]),
 };
+
 
 pub Expression: ast::Expression = {
     Addition,
@@ -62,22 +58,90 @@ pub Atom: ast::Atom = {
         ast::Atom::StringLiteral(s),
     <i:Identifier> => 
         ast::Atom::Variable(i),
-    GroupedExpression,
-    PrintExpression,
-    LetExpression,
-    Block,
+    <i:Instruction> => 
+        i,
+    // GroupedExpression,
+    // PrintExpression,
+    // LetExpression,
+    // IfElseExpression,
+    // Block,
 
 }
+
+pub Instruction: ast::Atom = {
+    <s:Statement> ";" => s,
+    <e:ExprNoSemi> => e,
+};
+
+// Instrucciones que requieren ;
+pub Statement: ast::Atom = {
+    PrintExpression,
+    LetExpression,
+};
+
+// Instrucciones que NO requieren ;
+pub ExprNoSemi: ast::Atom = {
+    IfElseExpression,
+    Block,
+    GroupedExpression,
+
+};
+
+pub Block: ast::Atom = {
+    <o:OpenBrace> <e:ExpressionList> <c:CloseBrace> => {
+        ast::Atom::new_block(o, e, c)
+    },
+};
 
 LetExpression: ast::Atom = {
     <k: Let> <a:AssignmentList> <i:In> <e:Atom>
         => ast::Atom::new_let_expression(k, a, i, e),
 }
 
+IfElseExpression: ast::Atom = {
+    <if_token:If> "(" <cond:Expression> ")" <then_branch:Atom>
+        <elifs:ElifBranchesOpt> <else_branch:ElseBranch> =>
+            ast::Atom::new_ifelse(
+                if_token,
+                Box::new(cond),
+                Box::new(then_branch),
+                elifs,
+                else_branch.0,
+                Box::new(else_branch.1)
+            ),
+};
+
+
+#[inline]
+ElifBranchesOpt: Vec<(tokens::Keyword, ast::Expression, ast::Atom)> = {
+    <e:ElifBranches> => e,
+    => vec![],
+};
+
+
+ElifBranches: Vec<(tokens::Keyword, ast::Expression, ast::Atom)> = {
+    <head:ElifBranch> <tail:ElifBranches> => {
+        let mut v = vec![head];
+        v.extend(tail);
+        v
+    },
+    <head:ElifBranch> => vec![head],
+};
+
+ElifBranch: (tokens::Keyword, ast::Expression, ast::Atom) = {
+    <elif_token:Elif> "(" <cond:Expression> ")" <body:Atom>
+        => (elif_token, cond, body),
+};
+
+ElseBranch: (tokens::Keyword, ast::Atom) = {
+    <else_token:Else> <body:Atom> => (else_token, body),
+};
+
 PrintExpression: ast::Atom = {
     <t:Print> "(" <e:Expression> ")" => 
         ast::Atom::new_print(t, e),
 };
+
 
 Assignment: ast::Assignment = {
     <id:Identifier> <o:EqualOperator> <e:Expression>
@@ -126,6 +190,21 @@ In: tokens::Keyword = {
 Print: tokens::Keyword = {
     <s: @L> "print" <e: @R>
         => tokens::Keyword::Print(tokens::Position::new(s, e)),
+};
+
+If: tokens::Keyword = {
+    <s: @L> "if" <e: @R>
+        => tokens::Keyword::If(tokens::Position::new(s, e)),
+};
+
+Elif: tokens::Keyword = {
+    <s: @L> "elif" <e: @R>
+        => tokens::Keyword::Elif(tokens::Position::new(s, e)),
+};
+
+Else: tokens::Keyword = {
+    <s: @L> "else" <e: @R>
+        => tokens::Keyword::Else(tokens::Position::new(s, e)),
 };
 
 NumLiteral: tokens::Literal   = {

--- a/src/parser/src/grammar.lalrpop
+++ b/src/parser/src/grammar.lalrpop
@@ -25,13 +25,7 @@ pub ExpressionList: ast::ExpressionList = {
 };
 
 pub Expression: ast::Expression = {
-    PrintExpression,
     Addition,
-};
-
-PrintExpression: ast::Expression = {
-    <s: @L> "print" "(" <e:Expression> ")" <e2: @R> => 
-        ast::Expression::new_print(e, tokens::Position::new(s, e2)),
 };
 
 pub Addition: ast::Expression = {
@@ -69,6 +63,7 @@ pub Atom: ast::Atom = {
     <i:Identifier> => 
         ast::Atom::Variable(i),
     GroupedExpression,
+    PrintExpression,
     LetExpression,
     Block,
 
@@ -78,6 +73,11 @@ LetExpression: ast::Atom = {
     <k: Let> <a:AssignmentList> <i:In> <e:Atom>
         => ast::Atom::new_let_expression(k, a, i, e),
 }
+
+PrintExpression: ast::Atom = {
+    <t:Print> "(" <e:Expression> ")" => 
+        ast::Atom::new_print(t, e),
+};
 
 Assignment: ast::Assignment = {
     <id:Identifier> <o:EqualOperator> <e:Expression>
@@ -121,6 +121,11 @@ Let: tokens::Keyword = {
 In: tokens::Keyword = {
     <s: @L> "in" <e: @R>
         => tokens::Keyword::In(tokens::Position::new(s, e)),
+};
+
+Print: tokens::Keyword = {
+    <s: @L> "print" <e: @R>
+        => tokens::Keyword::Print(tokens::Position::new(s, e)),
 };
 
 NumLiteral: tokens::Literal   = {


### PR DESCRIPTION
This pull request introduces significant updates to the parser and abstract syntax tree (AST) to support new language constructs (`if-else` and `print`) and refactors existing components for better organization and functionality. The changes include adding support for `if-else` expressions, refactoring the `print` functionality, and updating the grammar rules to align with these new constructs.

### New Features and Enhancements:
* **Support for `if-else` Expressions:**
  - Added a new `IfElse` struct in `src/parser/src/ast/atoms/ifelse.rs` to represent `if-else` constructs in the AST. It includes fields for the condition, `then` branch, optional `elif` branches, and an `else` branch.
  - Updated the `Atom` enum in `src/parser/src/ast/atoms/atom.rs` to include the `IfElse` variant and added a corresponding constructor method `new_ifelse`. [[1]](diffhunk://#diff-ea4d7a2a0fbccc9cb7a26cdf8bb43dcc0a1375afbf6879b8d0893b7b184ecaebR5-L17) [[2]](diffhunk://#diff-ea4d7a2a0fbccc9cb7a26cdf8bb43dcc0a1375afbf6879b8d0893b7b184ecaebR68-R89)
  - Extended the visitor pattern to handle `IfElse` nodes by adding a `visit_ifelse` method in the `Visitor` trait and implementing it in `AstPrinterVisitor` and `AstOptimizer`. [[1]](diffhunk://#diff-acc6084241a92ab7a9dd63471c5c80ce4f492e6bdb2f81ee11b057bdc55af63aL14-R19) [[2]](diffhunk://#diff-4b262f11bc9836d8e320e933597a59084dd2bad4623f22f9eb067c7b77e2a3c1L90-R133) [[3]](diffhunk://#diff-41bed6cf1c4efc1b90aa01ba76efc28388950c42ed343ff264326c42385d2639L94-R94)

* **Refactored `print` Functionality:**
  - Introduced a dedicated `Print` struct in `src/parser/src/ast/atoms/print.rs` to represent `print` statements in the AST.
  - Updated the `Atom` enum to include the `Print` variant and added a `new_print` constructor method. [[1]](diffhunk://#diff-ea4d7a2a0fbccc9cb7a26cdf8bb43dcc0a1375afbf6879b8d0893b7b184ecaebR5-L17) [[2]](diffhunk://#diff-ea4d7a2a0fbccc9cb7a26cdf8bb43dcc0a1375afbf6879b8d0893b7b184ecaebR68-R89)
  - Adjusted the visitor pattern to use the new `Print` struct, replacing the previous implementation that treated `print` as part of `Expression`. [[1]](diffhunk://#diff-41bed6cf1c4efc1b90aa01ba76efc28388950c42ed343ff264326c42385d2639L94-R94) [[2]](diffhunk://#diff-4b262f11bc9836d8e320e933597a59084dd2bad4623f22f9eb067c7b77e2a3c1L90-R133)

### Grammar and Parsing Updates:
* **Grammar Adjustments:**
  - Modified `src/parser/src/grammar.lalrpop` to add rules for parsing `if-else` expressions (`IfElseExpression`) and refactored the handling of `print` statements into the `Statement` category.
  - Introduced new tokens (`If`, `Elif`, `Else`, `Print`) to support the new constructs.

* **Parsing Improvements:**
  - Refactored the grammar to separate instructions that require semicolons (`Statement`) from those that do not (`ExprNoSemi`). This improves parsing clarity and aligns with the new constructs.

### Codebase Refactoring:
* **File Organization:**
  - Renamed `AstPrinterVisitor.rs` to `ast_printer_visitor.rs` for consistency with naming conventions.
  - Updated imports to reflect the new file structure and naming conventions.

* **Removed Legacy Code:**
  - Removed the old implementation of `print` as part of `Expression` and its associated grammar rules. (F443710eL8R8, [[1]](diffhunk://#diff-0337ae89f0ee1a1d456eec741b2c6aae3da94ff2547d4a6d5aa289f7e9f57d95L24-L26) [[2]](diffhunk://#diff-6a64e1fb4588722f68afa9d897d79ae75983fef976e8106af913e727dcf229f9L71-R145)

These changes collectively enhance the parser's capability to handle more complex language constructs and improve the maintainability of the codebase.