### PR TITLE
Operaciones booleanas, testeando condicionales y ciclos.

### DIFF
--- a/script.hulk
+++ b/script.hulk
@@ -1,14 +1,24 @@
-let a = 4 in
-    if (a % 2 == 0) {
-        print(a);
-        print("Even");
-    }
-    elif(a>=4 | true)
+
+let x=4 in {
+
+    if(x%2==1)
     {
-        print(a);
+        x:=print(x+1);;
+        print(true);
+        print("Hello");
+
     }
-    elif(false)
+     elif(x>=4 | true)
     {
-        print(a);
+        print(x);
     }
-    else print("Odd");;
+    else
+     print(x);
+
+    while(x<8)
+    {
+        print(x);
+        x:=x+1;
+    }
+
+};

--- a/script.hulk
+++ b/script.hulk
@@ -1,16 +1,14 @@
-let a = 0,b=1 in
+let a = 4 in
+    if (a % 2 == 0) {
+        print(a);
+        print("Even");
+    }
+    elif(a>=4 | true)
     {
-        print(b);
         print(a);
-        a:=a+3;
+    }
+    elif(false)
+    {
         print(a);
-    };
-
-{
-    let x=3 in print(x);;
-}
-
-if(false)
-print(2);
-else
-print(3);
+    }
+    else print("Odd");;

--- a/script.hulk
+++ b/script.hulk
@@ -1,4 +1,10 @@
-let x=2,y=let z=4 in z+1; in print(x*(2+y));;
+let a = 0,b=1 in
+    {
+        print(b);
+        print(a);
+        a:=a+3;
+        print(a);
+    };
 
 {
     let x=3 in print(x);;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use parser::grammar::ProgramParser;
+// use parser::grammar::ProgramParser;
 use parser::visitor::ast_printer_visitor::AstPrinterVisitor;
 use parser::visitor::LLVMGenerator;
 use parser::visitor::Visitable;

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,8 +95,7 @@ fn main() {
 
     let filename = &args[1];
 
-    let source = fs::read_to_string(filename)
-        .expect("No se pudo leer el archivo de entrada");
+    let source = fs::read_to_string(filename).expect("No se pudo leer el archivo de entrada");
 
     match parser::parse_program(&source) {
         Ok(program) => {
@@ -108,7 +107,20 @@ fn main() {
 
             // Escribir LLVM IR en archivo
             let mut file = File::create("build/script.ll").unwrap();
-            for line in LLVMGenerator::llvm_header() {
+            let header = LLVMGenerator::llvm_header();
+            let (before_main, after_main) = header.split_at(
+                header
+                    .iter()
+                    .position(|l| l.contains("define i32 @main()"))
+                    .unwrap(),
+            );
+            for line in before_main {
+                writeln!(file, "{}", line).unwrap();
+            }
+            for line in llvm_gen.string_globals {
+                writeln!(file, "{}", line).unwrap();
+            }
+            for line in after_main {
                 writeln!(file, "{}", line).unwrap();
             }
             for line in llvm_gen.code {

--- a/src/parser/src/ast/expressions/expressions.rs
+++ b/src/parser/src/ast/expressions/expressions.rs
@@ -14,6 +14,7 @@ pub enum Expression {
     Print(Box<Expression>, tokens::Position),
     While(Box<whilee::While>),
     Block(Box<block::Block>),
+    UnaryOp(UnaryOp),
     
 }
 
@@ -24,6 +25,11 @@ impl Expression {
 
     pub fn new_binary_op(left: Expression, right: Expression, operator: BinOp) -> Self {
         Expression::BinaryOp(BinaryOp::new(left, right, operator))
+    }
+
+    pub fn new_unary_op(op: tokens::UnaryOp, expr: Expression) -> Self
+    {
+        Expression::UnaryOp(UnaryOp::new(op, expr))
     }
 
     pub fn new_atom(atom: Atom) -> Self {
@@ -59,7 +65,7 @@ impl Visitable for Expression {
             Expression::While(whilee) => whilee.accept(visitor),
             Expression::LetIn(letin) => letin.accept(visitor),
             Expression::Block(block) => block.accept(visitor),
-            
+            Expression::UnaryOp(unoperator) => unoperator.accept(visitor),
         }
     }
 }

--- a/src/parser/src/ast/expressions/letin.rs
+++ b/src/parser/src/ast/expressions/letin.rs
@@ -14,7 +14,6 @@ pub struct Assignment {
 
 impl Assignment {
     pub fn new(variable: Atom, op: BinOp, body: Expression) -> Self {
-        println!(" Entro Assignment::new: {:?}", variable);
         match variable {
             
             Atom::Variable(identifier) => Assignment {

--- a/src/parser/src/ast/expressions/mod.rs
+++ b/src/parser/src/ast/expressions/mod.rs
@@ -16,5 +16,7 @@ pub mod block;
 pub use block::Block;
 pub use block::ExpressionList;
 
+pub mod unaryoperation;
+pub use unaryoperation::UnaryOp;
 
 

--- a/src/parser/src/ast/expressions/unaryoperation.rs
+++ b/src/parser/src/ast/expressions/unaryoperation.rs
@@ -1,0 +1,23 @@
+use crate::Expression;
+use crate::tokens;
+use crate::Visitable;
+use crate::Visitor;
+
+#[derive(Debug)]
+pub struct UnaryOp {
+    pub op: tokens::UnaryOp,
+    pub expr: Box<Expression>,
+}
+
+impl UnaryOp {
+    pub fn new(op: tokens::UnaryOp, expr: Expression) -> Self {
+        UnaryOp { op, expr: Box::new(expr) }
+    }
+}
+
+impl Visitable for UnaryOp {
+
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_unary_op(self);
+    }
+}

--- a/src/parser/src/ast/visitor/ast_optimizer.rs
+++ b/src/parser/src/ast/visitor/ast_optimizer.rs
@@ -1,7 +1,6 @@
 use crate::ast;
 use crate::ast::expressions::binoperation::BinaryOp;
 use crate::ast::visitor::{Visitable, Visitor};
-use crate::tokens::BinOp;
 
 pub struct AstOptimizer;
 
@@ -10,39 +9,38 @@ impl AstOptimizer {
         AstOptimizer
     }
 
-    fn merge_string_literals(&self, binop: &BinaryOp) -> Option<ast::Expression> {
-        if let BinOp::ConcatString(_) = binop.operator {
-            if let ast::Expression::Atom(left_atom) = &*binop.left {
-                if let ast::Expression::Atom(right_atom) = &*binop.right {
-                    if let ast::atoms::atom::Atom::StringLiteral(left_lit) = &**left_atom {
-                        if let ast::atoms::atom::Atom::StringLiteral(right_lit) = &**right_atom {
-                            // Merge the two string literals
-                            let merged_value = format!(
-                                "{}{}",
-                                left_lit.to_string_value(),
-                                right_lit.to_string_value()
-                            );
-                            return Some(ast::Expression::Atom(Box::new(
-                                ast::atoms::atom::Atom::new_string_literal(
-                                    left_lit.position().start(),
-                                    right_lit.position().end(),
-                                    &merged_value,
-                                ),
-                            )));
-                        }
-                    }
-                }
-            }
-        }
-        None
-    }
+    // fn merge_string_literals(&self, binop: &BinaryOp) -> Option<ast::Expression> {
+    //     if let BinOp::ConcatString(_) = binop.operator {
+    //         if let ast::Expression::Atom(left_atom) = &*binop.left {
+    //             if let ast::Expression::Atom(right_atom) = &*binop.right {
+    //                 if let ast::atoms::atom::Atom::StringLiteral(left_lit) = &**left_atom {
+    //                     if let ast::atoms::atom::Atom::StringLiteral(right_lit) = &**right_atom {
+    //                         // Merge the two string literals
+    //                         let merged_value = format!(
+    //                             "{}{}",
+    //                             left_lit.to_string(),
+    //                             right_lit.to_string()
+    //                         );
+    //                         return Some(ast::Expression::Atom(Box::new(
+    //                             ast::atoms::atom::Atom::new_string_literal(
+    //                                 left_lit.,
+    //                                 right_lit.position().end(),
+    //                                 &merged_value,
+    //                             ),
+    //                         )));
+    //                     }
+    //                 }
+    //             }
+    //         }
+    //     }
+    //     None
+    // }
 }
 
 impl Visitor for AstOptimizer {
+
     fn visit_program(&mut self, program: &ast::Program) {
-        for expr in &program.expressions {
-            expr.accept(self);
-        }
+        program.expression_list.accept(self);
     }
 
     fn visit_expression_list(&mut self, expr_list: &ast::ExpressionList) {
@@ -71,39 +69,76 @@ impl Visitor for AstOptimizer {
         // Nothing to optimize in atoms
     }
 
-    fn visit_binary_op(&mut self, binop: &BinaryOp) {
-        binop.left.accept(self);
-        binop.right.accept(self);
+    fn visit_binary_op(&mut self, _binop: &BinaryOp) {
+        // Primero, recorre los hijos
+        // binop.left.accept(self);
+        // binop.right.accept(self);
 
-        if let Some(merged_expr) = self.merge_string_literals(binop) {
-            // Here we would replace the current node with merged_expr in the AST
-            // But since we have immutable references, this requires a mutable AST or a transformation pass
-            // For now, this is a placeholder to indicate where merging would happen
+        // use crate::ast::atoms::atom::Atom::*;
+        // use crate::tokens::Literal;
+
+        // // Intenta reducir si ambos lados son literales
+        // if let (ast::Expression::Atom(left_atom), ast::Expression::Atom(rightAtom)) = (&*binop.left, &*binop.right) {
+        //     match (&**leftAtom, &**rightAtom, &binop.operator) {
+        //         // Comparaciones numéricas
+        //         (NumberLiteral(Literal::Number(l, _)), NumberLiteral(Literal::Number(r, _)), op) => {
+        //             let result = match op {
+        //                 BinOp::GreaterEqual(_) => l >= r,
+        //                 BinOp::Greater(_) => l > r,
+        //                 BinOp::LessEqual(_) => l <= r,
+        //                 BinOp::Less(_) => l < r,
+        //                 BinOp::EqualEqual(_) => l == r,
+        //                 BinOp::NotEqual(_) => l != r,
+        //                 _ => return,
+        //             };
+        //             // Aquí deberías reemplazar el nodo en el AST por un Atom::BooleanLiteral
+        //             // (esto requiere un AST mutable o una transformación, aquí solo es ejemplo)
+        //             // println!("Reducible: {} {:?} {} => {}", l, op, r, result);
+        //         }
+        //         // Operadores lógicos entre booleanos
+        //         (BooleanLiteral(Literal::Bool(l, _)), BooleanLiteral(Literal::Bool(r, _)), op) => {
+        //             let result = match op {
+        //                 BinOp::AndAnd(_) => *l && *r,
+        //                 BinOp::OrOr(_) => *l || *r,
+        //                 BinOp::EqualEqual(_) => l == r,
+        //                 BinOp::NotEqual(_) => l != r,
+        //                 _ => return,
+        //             };
+        //             // println!("Reducible: {} {:?} {} => {}", l, op, r, result);
+        //         }
+        //         _ => {}
+        //     }
         }
+
+    fn visit_letin(&mut self, _letin: &ast::expressions::letin::LetIn) {
+        // for assign in &letin.assignments {
+        //     assign.accept(self);
+        // }
+        // letin.expression.accept(self);
     }
 
-    fn visit_letin(&mut self, letin: &ast::atoms::letin::LetIn) {
-        for assign in &letin.assignments {
-            assign.accept(self);
-        }
-        letin.expression.accept(self);
+    fn visit_assignment(&mut self, _assign: &ast::expressions::letin::Assignment) {
+        // assign.expression.accept(self);
     }
 
-    fn visit_assignment(&mut self, assign: &ast::atoms::letin::Assignment) {
-        assign.expression.accept(self);
-    }
-
-    fn visit_block(&mut self, block: &ast::atoms::block::Block) {
-        for expr in &block.expressions.expressions {
-            expr.accept(self);
-        }
+    fn visit_block(&mut self, _block: &ast::expressions::block::Block) {
+        // for expr in &block.expressions.expressions {
+        //     expr.accept(self);
+        // }
     }
 
     fn visit_literal(&mut self, _literal: &crate::tokens::Literal) {}
 
     fn visit_identifier(&mut self, _identifier: &crate::tokens::Identifier) {}
 
-    fn visit_print(&mut self, expr: &ast::Expression, _pos: &crate::tokens::Position) {
+    fn visit_print(&mut self, expr: &ast::Expression) {
         expr.accept(self);
     }
+
+    fn visit_group(&mut self, _group: &ast::atoms::group::Group) {}
+
+    fn visit_unary_op(&mut self, _unary_op: &ast::expressions::unaryoperation::UnaryOp) {}
+
+    fn visit_while(&mut self, _whilee: &ast::whilee::While) {}
+
 }

--- a/src/parser/src/ast/visitor/ast_printer_visitor.rs
+++ b/src/parser/src/ast/visitor/ast_printer_visitor.rs
@@ -21,6 +21,7 @@ impl AstPrinterVisitor {
 }
 
 impl Visitor for AstPrinterVisitor {
+
     fn visit_program(&mut self, program: &ast::Program) {
         println!("{}Program", self.pad());
         self.indent += 1;
@@ -44,6 +45,7 @@ impl Visitor for AstPrinterVisitor {
             Expression::IfElse(ifelse) => ifelse.accept(self),
             Expression::LetIn(letin) => letin.accept(self),
             Expression::Block(block) => block.accept(self),
+            Expression::UnaryOp(unary_op) => unary_op.accept(self),
         }
     }
 
@@ -61,11 +63,23 @@ impl Visitor for AstPrinterVisitor {
         }
     }
     fn visit_binary_op(&mut self, binop: &ast::expressions::binoperation::BinaryOp) {
-        println!("{}BinaryOp: {}", self.pad(), binop.operator);
-        self.indent += 1;
-        binop.left.accept(self);
-        binop.right.accept(self);
-        self.indent -= 1;
+        use crate::tokens::BinOp;
+        match &binop.operator {
+            BinOp::Assign(_) => {
+                println!("{}DestructiveAssign:", self.pad());
+                self.indent += 1;
+                binop.left.accept(self);
+                binop.right.accept(self);
+                self.indent -= 1;
+            }
+            _ => {
+                println!("{}BinaryOp: {}", self.pad(), binop.operator);
+                self.indent += 1;
+                binop.left.accept(self);
+                binop.right.accept(self);
+                self.indent -= 1;
+            }
+        }
     }
     fn visit_letin(&mut self, letin: &ast::expressions::letin::LetIn) {
         println!("{}LetIn", self.pad());
@@ -155,5 +169,12 @@ impl Visitor for AstPrinterVisitor {
     fn visit_group(&mut self, group: &group::Group) {
         println!("{}Group", self.pad());
         group.expression.accept(self);
+    }
+
+    fn visit_unary_op(&mut self, unary_op: &ast::expressions::unaryoperation::UnaryOp) {
+        println!("{}UnaryOp: {}", self.pad(), unary_op.op);
+        self.indent += 1;
+        unary_op.expr.accept(self);
+        self.indent -= 1;
     }
 }

--- a/src/parser/src/ast/visitor/mod.rs
+++ b/src/parser/src/ast/visitor/mod.rs
@@ -1,9 +1,11 @@
 pub mod visitor;
 pub mod ast_printer_visitor;
 pub mod llvm_visitor;
+pub mod ast_optimizer;
 
 pub use visitor::Visitor;
 pub use visitor::Visitable;
 pub use ast_printer_visitor::AstPrinterVisitor;
 pub use llvm_visitor::LLVMGenerator;
+pub use ast_optimizer::AstOptimizer;
 

--- a/src/parser/src/ast/visitor/visitor.rs
+++ b/src/parser/src/ast/visitor/visitor.rs
@@ -16,6 +16,7 @@ pub trait Visitor {
     fn visit_while(&mut self, whilee: &whilee::While);
     fn visit_ifelse(&mut self, ifelse: &ast::expressions::ifelse::IfElse);
     fn visit_group(&mut self, group: &ast::atoms::group::Group);
+    fn visit_unary_op(&mut self, unary_op: &ast::expressions::unaryoperation::UnaryOp);
 }
 
 pub trait Visitable {

--- a/src/parser/src/grammar.lalrpop
+++ b/src/parser/src/grammar.lalrpop
@@ -200,7 +200,7 @@ BoolLiteral: tokens::Literal = {
 
 StrLiteral: tokens::Literal = {
    <s: @L> <v: r#""([^"\\]|\\.)*""#> <e: @R> => tokens::Literal::Str(
-        v.to_string(),
+        v[1..v.len()-1].to_string(),
         tokens::Position::new(s, e)
     ),
 };

--- a/src/parser/src/grammar.lalrpop
+++ b/src/parser/src/grammar.lalrpop
@@ -41,7 +41,7 @@ SemiColonExpression: ast::Expression = {
 NoSemiColonExpression: ast::Expression = {
     IfElseExpression,
     WhileExpression,
-    Addition,
+    BooleanExpr, //!!!!!!! Addition esta incluida en BooleanExpr
     Block,
     // Agrega aquí otras que no requieran ';'
 };
@@ -233,14 +233,16 @@ BooleanExpr: ast::Expression = {
 };
 
 ComparisonExpr: ast::Expression = {
+
     <l:Addition> <op:ComparisonOp> <r:Addition> => ast::Expression::new_binary_op(l, r, op),
     Addition,
+
 };
 
-UnaryExpr: ast::Expression = {
-    <op:UnaryOp> <e:UnaryExpr> => ast::Expression::new_unary_op(op, e),
-    BooleanExpr,
-};
+// UnaryExpr: ast::Expression = {
+//     <op:UnaryOp> <e:UnaryExpr> => ast::Expression::new_unary_op(op, e),
+//     Addition,
+// };
 
 ComparisonOp: tokens::BinOp = {
     <s: @L> "==" <e: @R> => tokens::BinOp::EqualEqual(tokens::Position::new(s, e)),
@@ -252,8 +254,8 @@ ComparisonOp: tokens::BinOp = {
 };
 
 LogicalOp: tokens::BinOp = {
-    <s: @L> "&&" <e: @R> => tokens::BinOp::AndAnd(tokens::Position::new(s, e)),
-    <s: @L> "||" <e: @R> => tokens::BinOp::OrOr(tokens::Position::new(s, e)),
+    <s: @L> "&" <e: @R> => tokens::BinOp::AndAnd(tokens::Position::new(s, e)),
+    <s: @L> "|" <e: @R> => tokens::BinOp::OrOr(tokens::Position::new(s, e)),
 };
 
 UnaryOp: tokens::UnaryOp = {

--- a/src/parser/src/grammar.lalrpop
+++ b/src/parser/src/grammar.lalrpop
@@ -34,6 +34,7 @@ pub Expression: ast::Expression = {
 SemiColonExpression: ast::Expression = {
     LetExpression,
     PrintExpression,
+    DestructiveAssign,
     // Agrega aquí otras que requieran ';'
 };
 
@@ -224,3 +225,52 @@ Elif: tokens::Keyword = {
 Else: tokens::Keyword = {
     <s: @L> "else" <e: @R> => tokens::Keyword::Else(tokens::Position::new(s, e)),
 };
+
+
+BooleanExpr: ast::Expression = {
+    <l:BooleanExpr> <op:LogicalOp> <r:ComparisonExpr> => ast::Expression::new_binary_op(l, r, op),
+    ComparisonExpr,
+};
+
+ComparisonExpr: ast::Expression = {
+    <l:Addition> <op:ComparisonOp> <r:Addition> => ast::Expression::new_binary_op(l, r, op),
+    Addition,
+};
+
+UnaryExpr: ast::Expression = {
+    <op:UnaryOp> <e:UnaryExpr> => ast::Expression::new_unary_op(op, e),
+    BooleanExpr,
+};
+
+ComparisonOp: tokens::BinOp = {
+    <s: @L> "==" <e: @R> => tokens::BinOp::EqualEqual(tokens::Position::new(s, e)),
+    <s: @L> "!=" <e: @R> => tokens::BinOp::NotEqual(tokens::Position::new(s, e)),
+    <s: @L> "<" <e: @R>  => tokens::BinOp::Less(tokens::Position::new(s, e)),
+    <s: @L> "<=" <e: @R> => tokens::BinOp::LessEqual(tokens::Position::new(s, e)),
+    <s: @L> ">" <e: @R>  => tokens::BinOp::Greater(tokens::Position::new(s, e)),
+    <s: @L> ">=" <e: @R> => tokens::BinOp::GreaterEqual(tokens::Position::new(s, e)),
+};
+
+LogicalOp: tokens::BinOp = {
+    <s: @L> "&&" <e: @R> => tokens::BinOp::AndAnd(tokens::Position::new(s, e)),
+    <s: @L> "||" <e: @R> => tokens::BinOp::OrOr(tokens::Position::new(s, e)),
+};
+
+UnaryOp: tokens::UnaryOp = {
+    <s: @L> "!" <e: @R> => tokens::UnaryOp::Not(tokens::Position::new(s, e)),
+    <s: @L> "-" <e: @R> => tokens::UnaryOp::Minus(tokens::Position::new(s, e)),
+}
+
+
+AssignDestructiveOperator: tokens::BinOp = {
+    <s: @L> ":=" <e: @R> => tokens::BinOp::Assign(tokens::Position::new(s, e)),
+};
+
+DestructiveAssign: ast::Expression = {
+    <v:Variable> <op:AssignDestructiveOperator> <e:Expression> => ast::Expression::new_binary_op(
+        ast::Expression::new_atom(v),
+        e,
+        op
+    ),
+};
+

--- a/src/parser/src/tokens/literal.rs
+++ b/src/parser/src/tokens/literal.rs
@@ -14,7 +14,7 @@ impl fmt::Display for Literal {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Literal::Number(n, _) => write!(f, "{}", n),
-            Literal::Str(s, _) => write!(f, "\"{}\"", s),
+            Literal::Str(s, _) => write!(f, "{}", s),
             Literal::Bool(b, _) => write!(f, "{}", b),
         }
     }


### PR DESCRIPTION
This pull request introduces significant changes to the Hulk Compiler's codebase, including the addition of a `Makefile` for build automation, an updated script example (`script.hulk`), and major refactoring of the parser and AST (Abstract Syntax Tree) implementation. The refactoring simplifies the codebase by removing unused modules and introducing new structures for handling grouped expressions, conditional logic, and loops.

### Build System Updates:
* **`Makefile`**: Added a `Makefile` for automating the build, run, and clean processes. It includes platform-specific handling for executable extensions and uses `clang` for generating executables from LLVM IR.

### Example Script:
* **`script.hulk`**: Included a new example script demonstrating conditional statements (`if`, `elif`, `else`), loops (`while`), and variable assignments.

### Parser and AST Refactoring:
#### Removed Unused Modules:
* **`src/noutilizados/ast.rs`, `src/noutilizados/error.rs`, `src/noutilizados/lexer.rs`, `src/noutilizados/parser.rs`**: Deleted legacy implementations of AST, error handling, lexer, and parser modules that were no longer in use. [[1]](diffhunk://#diff-38b5fcd099628dfee33ed2904de736294b88f78db0a6774617b73c6ed4da4eb4L1-L29) [[2]](diffhunk://#diff-32afb7171eff46edf4d9847a87bd1c2b9de66ba07077cf90b428ccb0786ee2efL1-L10) [[3]](diffhunk://#diff-02ac3a980aede10d1d0beb211e8e3b997d38458bd972d5cf0ae4388730e39f15L1-L105) [[4]](diffhunk://#diff-137248d0db4b7071da451f8ed376452647d90677b1231c2ccdb95aa78884c949L1-L132)

#### New AST Structures:
* **`src/parser/src/ast/atoms/group.rs`**: Introduced a `Group` struct for handling grouped expressions, with support for parentheses and visitor pattern integration.
* **`src/parser/src/ast/expressions/ifelse.rs`**: Added an `IfElse` struct to represent conditional logic, including support for `elif` branches and optional `else` blocks.

#### Expression Enhancements:
* **`src/parser/src/ast/expressions/expressions.rs`**: Expanded the `Expression` enum to include new variants like `IfElse`, `LetIn`, `While`, and `Block`. Updated visitor logic to handle these new variants.

#### Atom Updates:
* **`src/parser/src/ast/atoms/atom.rs`**: Removed legacy variants (`LetIn`, `Block`) and replaced them with new structures. Simplified visitor logic for atoms. [[1]](diffhunk://#diff-ea4d7a2a0fbccc9cb7a26cdf8bb43dcc0a1375afbf6879b8d0893b7b184ecaebL2-R29) [[2]](diffhunk://#diff-ea4d7a2a0fbccc9cb7a26cdf8bb43dcc0a1375afbf6879b8d0893b7b184ecaebL45-R52)

These changes collectively improve the Hulk Compiler's modularity, readability, and extensibility, paving the way for future enhancements.