### PR TITLE
Adding AST function call and function declaration

### DIFF
--- a/src/parser/src/ast/expressions/functioncall.rs
+++ b/src/parser/src/ast/expressions/functioncall.rs
@@ -1,0 +1,21 @@
+use super::super::{Visitable, Visitor};
+use crate::Expression;
+use crate::tokens::Identifier;
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct FunctionCall {
+    pub funct_name: Identifier,             
+    pub arguments: Vec<Expression>,
+}
+
+impl FunctionCall {
+    pub fn new(funct_name: Identifier, arguments: Vec<Expression>) -> Self {
+        FunctionCall { funct_name, arguments }
+    }
+}
+
+impl Visitable for FunctionCall {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_functcall(self);
+    }
+}

--- a/src/parser/src/ast/expressions/functiondeclaration.rs
+++ b/src/parser/src/ast/expressions/functiondeclaration.rs
@@ -1,0 +1,45 @@
+use super::super::{Visitable, Visitor};
+use crate::Expression;
+use crate::tokens::{Keyword, Identifier };
+
+#[derive(Debug, PartialEq,Clone)]
+pub struct FunctionParams {
+    pub name: Identifier,
+    pub signature: String,
+}
+
+impl FunctionParams {
+    pub fn new(name: Identifier, signature: String) -> Self {
+        FunctionParams {
+            name,
+            signature,
+        }
+    }
+}
+
+
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct FunctionDef {
+    pub name: Identifier,
+    pub params: Vec<FunctionParams>,
+    pub return_type: String,
+    pub body: Box<Expression>,
+}
+
+impl FunctionDef {
+    pub fn new_expr(name: Identifier, params: Vec<FunctionParams>, return_type: String, expr: Box<Expression>) -> Self {
+        FunctionDef {
+            name,
+            params,
+            return_type,
+            body: expr,
+        }
+    }
+}
+
+impl Visitable for FunctionDef {
+    fn accept<V: Visitor>(&self, visitor: &mut V) {
+        visitor.visit_functdef(self);
+    }
+}


### PR DESCRIPTION
This pull request introduces new abstractions for handling function-related constructs in the abstract syntax tree (AST) of the parser. Specifically, it adds support for representing function calls and function declarations, along with their associated parameters and behaviors. These changes enhance the modularity and extensibility of the codebase by implementing reusable structures and visitor patterns.

### Additions to Function Constructs in the AST:

* **Function Call Representation**:
  - Added the `FunctionCall` struct to represent function calls, including the function name (`Identifier`) and arguments (`Vec<Expression>`).
  - Implemented the `Visitable` trait for `FunctionCall`, enabling it to interact with visitors for traversal or processing.

* **Function Declaration Representation**:
  - Introduced the `FunctionParams` struct to encapsulate function parameter details, including the parameter name (`Identifier`) and its signature (`String`).
  - Added the `FunctionDef` struct to represent function declarations, including the function name (`Identifier`), parameters (`Vec<FunctionParams>`), return type (`String`), and body (`Box<Expression>`).
  - Implemented the `Visitable` trait for `FunctionDef`, allowing visitor-based operations on function declarations.